### PR TITLE
PL-1497 fetch circleci build artifacts

### DIFF
--- a/integrations/ci/circle.go
+++ b/integrations/ci/circle.go
@@ -169,13 +169,7 @@ func (c *Circle) DownloadArtifact(m *core.Manifest, fname, path string) error {
 
 	for _, a := range arr {
 		if strings.Contains(a.URL, fname) {
-			if len(a.URL) > 0 {
-				err := utils.DownloadFile(path, fmt.Sprintf("%s?circle-token=%s", a.URL, c.client.Token))
-				if err != nil {
-					return err
-				}
-				return nil
-			}
+			return utils.DownloadFile(path, fmt.Sprintf("%s?circle-token=%s", a.URL, c.client.Token))
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,16 +1,17 @@
 package main
 
 import (
+	"os"
+
 	"github.com/benchlabs/bub/cmd"
 	"github.com/urfave/cli"
-	"os"
 )
 
 func main() {
 	app := cli.NewApp()
 	app.Name = "bub"
 	app.Usage = "A tool for all your needs."
-	app.Version = "0.59.0"
+	app.Version = "0.60.0"
 	app.EnableBashCompletion = true
 	app.Commands = cmd.BuildCmds()
 	app.Run(os.Args)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,17 +2,19 @@ package utils
 
 import (
 	"errors"
-	"github.com/manifoldco/promptui"
 	"io"
 	"io/ioutil"
 	"log"
 	"math/rand"
+	"net/http"
 	"os"
 	"os/exec"
 	"path"
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/manifoldco/promptui"
 )
 
 var (
@@ -221,4 +223,25 @@ func Contains(str string, haystack ...string) bool {
 		}
 	}
 	return false
+}
+
+func DownloadFile(path string, url string) error {
+	out, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
This code adds functionality to download build artifact from circleci using bub

Assumptions:
1. bub assumes that you are in the repo dir you need to run the command for
2. The new code reuses the code from ```bub check``` which assumes that you want the artifact of the latest build from current HEAD

Usage is like so :
```
bub circle artifact -h # Shows help menu
bub circle artifact -p $HOME junit.xml # Downloads the junit.xml artifact to $HOME dir
bub circle artifact -p $HOME/dir-thats-not-there junit.xml # Throws error and exits with exit code 1
bub circle artifact junit.xml # Downloads the junit.xml file to current dir
bub circle artifact artifact-thats-not-there.xml # NOOP : Doesnt do anything
```